### PR TITLE
Deprecated field and typo

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -1,9 +1,8 @@
 {
     "type": "MOD_INFO",
-    "mod_type": "SUPPLEMENTAL",
     "ident": "CIVILIANPOWAAA",
     "name": "CIVILIAN POWER ARMOR",
     "description": "Adds a few power armor items",
-    "author": "MATTYMCAIN",
+    "authors": "MATTYMCAIN",
     "path": ""
 }


### PR DESCRIPTION
mod-type is covered by "category" now. "author" needs to be "authors" for the game to read it correctly.